### PR TITLE
Add support for github commit status pending

### DIFF
--- a/jenkins_jobs/modules/builders.py
+++ b/jenkins_jobs/modules/builders.py
@@ -1639,3 +1639,17 @@ def cmake(parser, xml_parent, data):
     # The plugin generates this tag, but there doesn't seem to be anything
     # that can be configurable by it. Let's keep it to mantain compatibility:
     XML.SubElement(cmake, 'builderImpl')
+
+
+def github_notifier(parser, xml_parent, data):
+    """yaml: github-notifier
+    Set pending build status on Github commit.
+    Requires the Jenkins `Github Plugin.
+    <https://wiki.jenkins-ci.org/display/JENKINS/GitHub+Plugin>`_
+
+    Example:
+
+    .. literalinclude:: /../../tests/builders/fixtures/github-notifier.yaml
+    """
+    XML.SubElement(xml_parent,
+                   'com.cloudbees.jenkins.GitHubSetCommitStatusBuilder')

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,6 +53,7 @@ jenkins_jobs.builders =
     copyartifact=jenkins_jobs.modules.builders:copyartifact
     critical-block-start=jenkins_jobs.modules.builders:critical_block_start
     critical-block-end=jenkins_jobs.modules.builders:critical_block_end
+    github-notifier=jenkins_jobs.modules.builders:github_notifier
     gradle=jenkins_jobs.modules.builders:gradle
     grails=jenkins_jobs.modules.builders:grails
     groovy=jenkins_jobs.modules.builders:groovy

--- a/tests/builders/fixtures/github-notifier.xml
+++ b/tests/builders/fixtures/github-notifier.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<project>
+  <builders>
+    <com.cloudbees.jenkins.GitHubSetCommitStatusBuilder/>
+  </builders>
+</project>

--- a/tests/builders/fixtures/github-notifier.yaml
+++ b/tests/builders/fixtures/github-notifier.yaml
@@ -1,0 +1,2 @@
+builders:
+  - github-notifier


### PR DESCRIPTION
Introduced in the github plugin at version 1.10:
'Build step to set Github commit status as "pending"'

Change-Id: I6c586ae44563608f095fff1eb65395d0338d7cb4
